### PR TITLE
Added simple Hello support

### DIFF
--- a/src/KeePass.Win.Services/HelloProvider.cs
+++ b/src/KeePass.Win.Services/HelloProvider.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Windows.Security.Credentials;
+using Windows.Security.Credentials.UI;
+using Windows.UI.Xaml;
+
+namespace KeePass.Win.Services
+{
+    public class HelloProvider
+    {
+        private readonly String HelloStorageTag = Application.Current.GetType().ToString();
+        private String DefaultUserName = "HelloUser";
+
+        private PasswordVault _Vault = null;
+        private PasswordVault Vault
+        {
+            get
+            {
+                if (_Vault == null)
+                {
+                    _Vault = new PasswordVault();
+                }
+                return _Vault;
+            }
+        }
+
+        private void ClearAllKeys()
+        {
+            IReadOnlyList<PasswordCredential> SymmetricKeys = Vault.RetrieveAll();
+
+            foreach (PasswordCredential symmetricKey in SymmetricKeys)
+            {
+                Vault.Remove(symmetricKey);
+            }
+        }
+
+        private String _RequestVerificationMessage = null;
+        private String RequestVerificationMessage
+        {
+            get
+            {
+                if (_RequestVerificationMessage == null)
+                {
+                    _RequestVerificationMessage = "Auto login"; //Get localized message.
+                }
+
+                return _RequestVerificationMessage;
+            }
+        }
+
+        public async Task<Boolean> IsSupportedAsync()
+        {
+            return await KeyCredentialManager.IsSupportedAsync();
+        }
+
+
+        private PasswordCredential GetValueFromLocker(string resourceName, string userName)
+        {
+            PasswordCredential Credentials = null;
+
+            try
+            {
+                List<PasswordCredential> CredentialsList = new List<PasswordCredential>();
+
+                IReadOnlyList<PasswordCredential> AllKeys = Vault.RetrieveAll();
+
+                int Count = AllKeys.Count;
+                foreach (PasswordCredential item in AllKeys)
+                {
+                    if (item.Resource.Equals(resourceName))
+                    {
+                        CredentialsList.Add(item);
+                    }
+                }
+
+                if (CredentialsList.Count > 0)
+                {
+                    if (CredentialsList.Count == 1)
+                    {
+                        Credentials = CredentialsList[0];
+                    }
+                    else
+                    {
+                        if (userName != null)
+                        {
+                            Credentials = Vault.Retrieve(resourceName, userName);
+                        }
+                        else
+                        {
+                            Credentials = Vault.Retrieve(resourceName, DefaultUserName);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex )
+            {
+                String a = ex.ToString();
+            }
+
+            return Credentials;
+        }
+
+        private String GetCredentialsTag(String fileId)
+        {
+            return HelloStorageTag + '/' + fileId;
+        }
+
+        public Boolean SetCredentialsForFileId(String fileId, String userName, String value)
+        {
+            try
+            {
+                PasswordCredential StoredCredentials = GetValueFromLocker(GetCredentialsTag(fileId), userName);
+                if (StoredCredentials != null)
+                {
+                    Vault.Remove(StoredCredentials);
+                }
+
+                PasswordCredential NewCredential = null;
+
+                if (userName != null)
+                {
+                    NewCredential = new PasswordCredential(GetCredentialsTag(fileId), userName, value);
+                }
+                else
+                {
+                    NewCredential = new PasswordCredential(GetCredentialsTag(fileId), DefaultUserName, value);
+                }
+
+                Boolean PasswordMatch = false;
+                if (NewCredential.Password.Length > 0)
+                {
+                    Vault.Add(NewCredential);
+                    PasswordMatch = true;
+                }
+
+                return PasswordMatch;
+            }
+            catch (Exception)
+            {
+                //TODO: Log
+            }
+
+            return false;
+        }
+        public async Task<PasswordCredential> GetCredentialsForFileId(String fileId, String userName)
+        {
+            PasswordCredential Credentials = GetValueFromLocker(GetCredentialsTag(fileId), userName);
+
+            try
+            {
+                if (Credentials != null && await UserConsentVerifier.RequestVerificationAsync(RequestVerificationMessage) == UserConsentVerificationResult.Verified)
+                {
+                    Credentials.RetrievePassword();
+                    if (Credentials.Password?.Length > 0)
+                    {
+                        return Credentials;
+                    }
+                    else
+                    {
+                        Vault.Remove(Credentials);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                //TODO: Log
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/KeePass.Win.Services/KeePass.Win.Services.csproj
+++ b/src/KeePass.Win.Services/KeePass.Win.Services.csproj
@@ -106,6 +106,7 @@
   <ItemGroup>
     <Compile Include="DataPackageClipboard.cs" />
     <Compile Include="FileDatabaseTracker.cs" />
+    <Compile Include="HelloProvider.cs" />
     <Compile Include="LocalizedStrings.cs" />
     <Compile Include="MessageBoxDialogs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/KeePassLib/DatabaseCache.cs
+++ b/src/KeePassLib/DatabaseCache.cs
@@ -40,7 +40,14 @@ namespace KeePass
 
             Log.Info("Successfully retrieved credentials for {Database}", id);
 
-            return await UnlockAsync(dbFile, credentials);
+            IKeePassDatabase UnlockedDatabase = await UnlockAsync(dbFile, credentials);
+
+            if (UnlockedDatabase != null)
+            {
+                credentialProvider.SetCredentialsAsync(dbFile, credentials);
+            }
+
+            return UnlockedDatabase;
         }
 
         public abstract Task<IKeePassDatabase> UnlockAsync(IFile dbFile, KeePassCredentials credentials);

--- a/src/KeePassLib/ICredentialProvider.cs
+++ b/src/KeePassLib/ICredentialProvider.cs
@@ -1,9 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace KeePass
 {
     public interface ICredentialProvider
     {
         Task<KeePassCredentials> GetCredentialsAsync(IFile file);
+        Boolean SetCredentialsAsync(IFile file, KeePassCredentials credentials);
     }
 }

--- a/src/KeePassWin/Services/DialogCredentialProvider.cs
+++ b/src/KeePassWin/Services/DialogCredentialProvider.cs
@@ -1,6 +1,7 @@
 ﻿using KeePass.Win.Views;
 using System;
 using System.Threading.Tasks;
+using Windows.Security.Credentials;
 
 namespace KeePass.Win.Services
 {
@@ -8,22 +9,43 @@ namespace KeePass.Win.Services
     {
         private readonly Func<IFile, PasswordDialog> _dialogFactory;
 
+        private readonly HelloProvider Hello = new HelloProvider();
+
         public DialogCredentialProvider(Func<IFile, PasswordDialog> dialogFactory)
         {
             _dialogFactory = dialogFactory;
         }
 
+        public Boolean SetCredentialsAsync(IFile file, KeePassCredentials credentials)
+        {
+            return Hello.SetCredentialsForFileId(file.Name, null, credentials.Password);
+        }
+
         public async Task<KeePassCredentials> GetCredentialsAsync(IFile file)
         {
-            var dialog = _dialogFactory(file);
-            var model = await dialog.GetModelAsync();
-
-            if (model == null)
+            PasswordCredential StoredCredentials = null;
+            if (await Hello.IsSupportedAsync())
             {
-                return default(KeePassCredentials);
+                StoredCredentials = await Hello.GetCredentialsForFileId(file.Name, null);
             }
 
-            return new KeePassCredentials(model.KeyFile, model.Password);
+            if (StoredCredentials == null)
+            {
+                var dialog = _dialogFactory(file);
+                var model = await dialog.GetModelAsync();
+
+                if (model == null)
+                {
+                    return default(KeePassCredentials);
+                }
+
+                return new KeePassCredentials(model.KeyFile, model.Password);
+            }
+            else
+            {
+                StoredCredentials.RetrievePassword();
+                return new KeePassCredentials(null, StoredCredentials.Password);
+            }
         }
     }
 }


### PR DESCRIPTION
I got this working version working in a very simple way. In case of DB open success, the password is stored in the CredentialVault. When getting credentials to open a DB, before prompting for password, it tries getting credentials from the vault, validate by Windows Hello. For now, no keyfile support, some crude key addressing and hardcoded strings (just one, I think).